### PR TITLE
Make code Django 1.8 compatible

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,4 +55,4 @@ For example:
     	{% endfor %}
 	</div>
 	
-7.Make sure `python manage.py update_tweets` is regurlalry called.
+7.Make sure `python manage.py update_tweets` is regularly called.

--- a/twitter_feed/import_tweets.py
+++ b/twitter_feed/import_tweets.py
@@ -38,15 +38,13 @@ class ImportTweets:
 
         return tweet
 
-    @transaction.commit_manually
+    @transaction.atomic
     def _replace_all_tweets(self, new_tweets):
         try:
-            with transaction.commit_manually():
+            with transaction.atomic():
                 Tweet.objects.remove_all()
 
                 for tweet in new_tweets:
                     tweet.save()
-
-                transaction.commit()
         except Exception:
             pass


### PR DESCRIPTION
This change would break the code for previous versions of Django, so either we could put some detection in there, or simply tag it and you need to get an older version if you want < Django 1.8 support.
